### PR TITLE
Add HEIC/AVIF format support

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -22,6 +22,15 @@ jobs:
         with:
           targets: x86_64-pc-windows-msvc
 
+      - name: Install MSVC and vcpkg
+        uses: ilammy/msvc-dev-cmd@v1
+
+      - name: Install libheif via vcpkg
+        shell: pwsh
+        run: |
+          vcpkg install libheif:x64-windows --clean-after-build
+          vcpkg integrate install
+
       - name: Setup Bun
         uses: oven-sh/setup-bun@v2
         with:
@@ -48,6 +57,8 @@ jobs:
 
       - name: Build app
         run: bun run tauri build
+        env:
+          VCPKG_ROOT: ${{ env.VCPKG_INSTALLATION_ROOT }}
 
       - name: Compress Windows executable
         shell: pwsh

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -25,10 +25,10 @@ jobs:
       - name: Install MSVC and vcpkg
         uses: ilammy/msvc-dev-cmd@v1
 
-      - name: Install libheif via vcpkg
+      - name: Install libheif and libavif via vcpkg
         shell: pwsh
         run: |
-          vcpkg install libheif:x64-windows --clean-after-build
+          vcpkg install libheif:x64-windows libavif:x64-windows --clean-after-build
           vcpkg integrate install
 
       - name: Setup Bun

--- a/README.ja.md
+++ b/README.ja.md
@@ -50,11 +50,11 @@
 - **Rust** & Cargo ([rustup](https://rustup.rs/) 経由でインストール)
 - Tauri の **システム依存関係** ([Tauri Prerequisites](https://tauri.app/v1/guides/getting-started/prerequisites) を参照)
 - **画像フォーマットライブラリ** (HEIC/HEIF および AVIF サポートに必要):
-  - **macOS**: 
+  - **macOS**:
     ```bash
     brew install libheif libavif meson ninja cmake
     ```
-  - **Ubuntu/Debian**: 
+  - **Ubuntu/Debian**:
     ```bash
     sudo apt install libheif-dev libavif-dev meson ninja-build cmake
     ```

--- a/README.ja.md
+++ b/README.ja.md
@@ -49,9 +49,15 @@
 - **Node.js** (または [Bun](https://bun.sh/))
 - **Rust** & Cargo ([rustup](https://rustup.rs/) 経由でインストール)
 - Tauri の **システム依存関係** ([Tauri Prerequisites](https://tauri.app/v1/guides/getting-started/prerequisites) を参照)
-- **libheif** (HEIC/HEIF サポートに必要):
-  - **macOS**: `brew install libheif`
-  - **Ubuntu/Debian**: `sudo apt install libheif-dev`
+- **画像フォーマットライブラリ** (HEIC/HEIF および AVIF サポートに必要):
+  - **macOS**: 
+    ```bash
+    brew install libheif libavif meson ninja cmake
+    ```
+  - **Ubuntu/Debian**: 
+    ```bash
+    sudo apt install libheif-dev libavif-dev meson ninja-build cmake
+    ```
   - **Windows**: GitHub Actions CI/CD で vcpkg 経由で自動処理
 
 ### インストール (Installation)

--- a/README.ja.md
+++ b/README.ja.md
@@ -11,8 +11,11 @@
 - **高速変換**: Rust 製エンジンによる爆速画像処理。
 - **ドラッグ & ドロップ**: 直感的なドラッグ & ドロップエリアで簡単にファイルを選択。
 - **対応フォーマット**:
-  - **入力**: JPG, PNG, WEBP, HEIC
-  - **出力**: JPG, PNG, WEBP
+  - **入力**: JPG, PNG, WEBP, AVIF, HEIC/HEIF
+  - **出力**: JPG, PNG, WEBP, AVIF, HEIC
+- **品質制御**:
+  - 圧縮品質の調整（0〜100）。
+  - PNG、WEBP、AVIF でのロスレス圧縮サポート。
 - **カスタマイズ可能な設定**:
   - デフォルトの出力ディレクトリの設定。
   - ファイル名のカスタマイズ（接頭辞、競合時の解決方法）。
@@ -29,7 +32,10 @@
 - **バックエンド / コア**:
     - [Tauri](https://tauri.app/) (v2)
     - [Rust](https://www.rust-lang.org/)
-    - [image](https://github.com/image-rs/image) crate
+    - [image](https://github.com/image-rs/image) crate (AVIF サポート付き)
+    - [libheif-rs](https://github.com/Cykooz/libheif-rs) (HEIC/HEIF サポート)
+    - [webpx](https://crates.io/crates/webpx) (WebP エンコーディング)
+    - [imagequant](https://crates.io/crates/imagequant) (ロッシー PNG 圧縮)
 - **ビルドツール**:
     - [Vite](https://vitejs.dev/)
     - [Bun](https://bun.sh/) (Package Manager)
@@ -43,6 +49,10 @@
 - **Node.js** (または [Bun](https://bun.sh/))
 - **Rust** & Cargo ([rustup](https://rustup.rs/) 経由でインストール)
 - Tauri の **システム依存関係** ([Tauri Prerequisites](https://tauri.app/v1/guides/getting-started/prerequisites) を参照)
+- **libheif** (HEIC/HEIF サポートに必要):
+  - **macOS**: `brew install libheif`
+  - **Ubuntu/Debian**: `sudo apt install libheif-dev`
+  - **Windows**: GitHub Actions CI/CD で vcpkg 経由で自動処理
 
 ### インストール (Installation)
 
@@ -77,9 +87,10 @@
 ## 使い方 (Usage)
 
 1. **画像を選択**: 画像をウィンドウにドラッグ & ドロップするか、クリックしてファイルを選択します。
-2. **フォーマットを選択**: 希望する出力フォーマット (JPG, PNG, WEBP) を選択します。
-3. **変換**: "Convert" ボタンをクリックして画像を処理します。
-4. **設定**: 設定メニューを使用して、出力パス、ファイル名の接頭辞、テーマを設定します。
+2. **フォーマットを選択**: 希望する出力フォーマット (JPG, PNG, WEBP, AVIF, HEIC) を選択します。
+3. **品質調整**: 品質スライダーで圧縮率を制御します（ロッシー形式に適用）。
+4. **変換**: "Convert" ボタンをクリックして画像を処理します。
+5. **設定**: 設定メニューから出力パス、ファイル名接頭辞、競合解決、テーマを設定します。
 
 ## 本番ビルド (Building for Production)
 

--- a/README.md
+++ b/README.md
@@ -50,11 +50,11 @@ Ensure you have the following installed on your machine:
 - **Rust** & Cargo (Install via [rustup](https://rustup.rs/))
 - **System Dependencies** for Tauri (see [Tauri Prerequisites](https://tauri.app/v1/guides/getting-started/prerequisites))
 - **Image Format Libraries** (required for HEIC/HEIF and AVIF support):
-  - **macOS**: 
+  - **macOS**:
     ```bash
     brew install libheif libavif meson ninja cmake
     ```
-  - **Ubuntu/Debian**: 
+  - **Ubuntu/Debian**:
     ```bash
     sudo apt install libheif-dev libavif-dev meson ninja-build cmake
     ```

--- a/README.md
+++ b/README.md
@@ -11,8 +11,11 @@ A modern, fast, and lightweight image converter application built with [Tauri](h
 - **High-Performance Conversion**: Powered by Rust for blazing fast image processing.
 - **Drag & Drop Interface**: Intuitive drag-and-drop area for easy file selection.
 - **Format Support**:
-  - **Input**: JPG, PNG, WEBP, HEIC
-  - **Output**: JPG, PNG, WEBP
+  - **Input**: JPG, PNG, WEBP, AVIF, HEIC/HEIF
+  - **Output**: JPG, PNG, WEBP, AVIF, HEIC
+- **Quality Control**:
+  - Adjustable compression quality (0-100).
+  - Lossless compression support for PNG, WEBP, AVIF.
 - **Customizable Settings**:
   - Set default output directory.
   - File naming customization (prefix, conflict resolution).
@@ -29,7 +32,10 @@ A modern, fast, and lightweight image converter application built with [Tauri](h
 - **Backend / Core**:
     - [Tauri](https://tauri.app/) (v2)
     - [Rust](https://www.rust-lang.org/)
-    - [image](https://github.com/image-rs/image) crate
+    - [image](https://github.com/image-rs/image) crate (with AVIF support)
+    - [libheif-rs](https://github.com/Cykooz/libheif-rs) (HEIC/HEIF support)
+    - [webpx](https://crates.io/crates/webpx) (WebP encoding)
+    - [imagequant](https://crates.io/crates/imagequant) (Lossy PNG compression)
 - **Build Tools**:
     - [Vite](https://vitejs.dev/)
     - [Bun](https://bun.sh/) (Package Manager)
@@ -43,6 +49,10 @@ Ensure you have the following installed on your machine:
 - **Node.js** (or [Bun](https://bun.sh/))
 - **Rust** & Cargo (Install via [rustup](https://rustup.rs/))
 - **System Dependencies** for Tauri (see [Tauri Prerequisites](https://tauri.app/v1/guides/getting-started/prerequisites))
+- **libheif** (required for HEIC/HEIF support):
+  - **macOS**: `brew install libheif`
+  - **Ubuntu/Debian**: `sudo apt install libheif-dev`
+  - **Windows**: Automatically handled via vcpkg in GitHub Actions CI/CD
 
 ### Installation
 
@@ -77,9 +87,10 @@ This will start the Vite dev server and launch the Tauri application window.
 ## Usage
 
 1. **Select Images**: Drag and drop images onto the window or click to select files.
-2. **Choose Format**: Select the desired output format (JPG, PNG, WEBP).
-3. **Convert**: Click the "Convert" button to process the images.
-4. **Settings**: Use the settings menu to configure output paths, filename prefixes, and themes.
+2. **Choose Format**: Select the desired output format (JPG, PNG, WEBP, AVIF, HEIC).
+3. **Adjust Quality**: Use the quality slider to control compression (applies to lossy formats).
+4. **Convert**: Click the "Convert" button to process the images.
+5. **Settings**: Use the settings menu to configure output paths, filename prefixes, conflict resolution, and themes.
 
 ## Building for Production
 

--- a/README.md
+++ b/README.md
@@ -49,9 +49,15 @@ Ensure you have the following installed on your machine:
 - **Node.js** (or [Bun](https://bun.sh/))
 - **Rust** & Cargo (Install via [rustup](https://rustup.rs/))
 - **System Dependencies** for Tauri (see [Tauri Prerequisites](https://tauri.app/v1/guides/getting-started/prerequisites))
-- **libheif** (required for HEIC/HEIF support):
-  - **macOS**: `brew install libheif`
-  - **Ubuntu/Debian**: `sudo apt install libheif-dev`
+- **Image Format Libraries** (required for HEIC/HEIF and AVIF support):
+  - **macOS**: 
+    ```bash
+    brew install libheif libavif meson ninja cmake
+    ```
+  - **Ubuntu/Debian**: 
+    ```bash
+    sudo apt install libheif-dev libavif-dev meson ninja-build cmake
+    ```
   - **Windows**: Automatically handled via vcpkg in GitHub Actions CI/CD
 
 ### Installation

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -248,7 +248,7 @@ dependencies = [
  "glib-sys",
  "gobject-sys",
  "libc",
- "system-deps",
+ "system-deps 6.2.2",
 ]
 
 [[package]]
@@ -461,7 +461,7 @@ checksum = "685c9fa8e590b8b3d678873528d83411db17242a73fccaed827770ea0fedda51"
 dependencies = [
  "glib-sys",
  "libc",
- "system-deps",
+ "system-deps 6.2.2",
 ]
 
 [[package]]
@@ -542,7 +542,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d067ad48b8650848b989a59a86c6c36a995d02d2bf778d45c3c5d57bc2718f02"
 dependencies = [
  "smallvec",
- "target-lexicon",
+ "target-lexicon 0.12.16",
+]
+
+[[package]]
+name = "cfg-expr"
+version = "0.20.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "78cef5b5a1a6827c7322ae2a636368a573006b27cfa76c7ebd53e834daeaab6a"
+dependencies = [
+ "smallvec",
+ "target-lexicon 0.13.3",
 ]
 
 [[package]]
@@ -1345,7 +1355,7 @@ dependencies = [
  "glib-sys",
  "gobject-sys",
  "libc",
- "system-deps",
+ "system-deps 6.2.2",
 ]
 
 [[package]]
@@ -1362,7 +1372,7 @@ dependencies = [
  "libc",
  "pango-sys",
  "pkg-config",
- "system-deps",
+ "system-deps 6.2.2",
 ]
 
 [[package]]
@@ -1376,7 +1386,7 @@ dependencies = [
  "gobject-sys",
  "libc",
  "pkg-config",
- "system-deps",
+ "system-deps 6.2.2",
 ]
 
 [[package]]
@@ -1402,7 +1412,7 @@ dependencies = [
  "gdk-sys",
  "glib-sys",
  "libc",
- "system-deps",
+ "system-deps 6.2.2",
  "x11",
 ]
 
@@ -1501,7 +1511,7 @@ dependencies = [
  "glib-sys",
  "gobject-sys",
  "libc",
- "system-deps",
+ "system-deps 6.2.2",
  "winapi",
 ]
 
@@ -1549,7 +1559,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "063ce2eb6a8d0ea93d2bf8ba1957e78dbab6be1c2220dd3daca57d5a9d869898"
 dependencies = [
  "libc",
- "system-deps",
+ "system-deps 6.2.2",
 ]
 
 [[package]]
@@ -1566,7 +1576,7 @@ checksum = "0850127b514d1c4a4654ead6dedadb18198999985908e6ffe4436f53c785ce44"
 dependencies = [
  "glib-sys",
  "libc",
- "system-deps",
+ "system-deps 6.2.2",
 ]
 
 [[package]]
@@ -1605,7 +1615,7 @@ dependencies = [
  "gobject-sys",
  "libc",
  "pango-sys",
- "system-deps",
+ "system-deps 6.2.2",
 ]
 
 [[package]]
@@ -2101,7 +2111,7 @@ dependencies = [
  "glib-sys",
  "gobject-sys",
  "libc",
- "system-deps",
+ "system-deps 6.2.2",
 ]
 
 [[package]]
@@ -2251,24 +2261,27 @@ dependencies = [
 
 [[package]]
 name = "libheif-rs"
-version = "1.1.0"
+version = "2.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e4a26370abb4723a3ce73083e479b98017604206cadb0e35da5eac4813600d85"
+checksum = "5de2912bca071d0f609cd6cb8d348c475439f69e808726374bea9e079591559e"
 dependencies = [
+ "cfg-if",
  "enumn",
  "four-cc",
+ "image",
  "libc",
  "libheif-sys",
 ]
 
 [[package]]
 name = "libheif-sys"
-version = "3.1.0+1.18.2"
+version = "5.1.1+1.21.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e663db80d4272b60c066c5a9d17370ffa0433a31d424152f95f1e1effb9b3860"
+checksum = "03b69722f9386e24ae14655f8faddff28cb6a9a5511d7ffdde3a4499b51cca07"
 dependencies = [
+ "cfg-if",
  "libc",
- "pkg-config",
+ "system-deps 7.0.7",
  "vcpkg",
  "walkdir",
 ]
@@ -2863,7 +2876,7 @@ dependencies = [
  "glib-sys",
  "gobject-sys",
  "libc",
- "system-deps",
+ "system-deps 6.2.2",
 ]
 
 [[package]]
@@ -4051,7 +4064,7 @@ dependencies = [
  "glib-sys",
  "gobject-sys",
  "libc",
- "system-deps",
+ "system-deps 6.2.2",
 ]
 
 [[package]]
@@ -4150,10 +4163,23 @@ version = "6.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a3e535eb8dded36d55ec13eddacd30dec501792ff23a0b1682c38601b8cf2349"
 dependencies = [
- "cfg-expr",
+ "cfg-expr 0.15.8",
  "heck 0.5.0",
  "pkg-config",
  "toml 0.8.2",
+ "version-compare",
+]
+
+[[package]]
+name = "system-deps"
+version = "7.0.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "48c8f33736f986f16d69b6cb8b03f55ddcad5c41acc4ccc39dd88e84aa805e7f"
+dependencies = [
+ "cfg-expr 0.20.6",
+ "heck 0.5.0",
+ "pkg-config",
+ "toml 0.9.12+spec-1.1.0",
  "version-compare",
 ]
 
@@ -4213,6 +4239,12 @@ name = "target-lexicon"
 version = "0.12.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "61c41af27dd6d1e27b1b16b489db798443478cef1f06a660c96db617ba5de3b1"
+
+[[package]]
+name = "target-lexicon"
+version = "0.13.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "df7f62577c25e07834649fc3b39fafdc597c0a3527dc1c60129201ccfcbaa50c"
 
 [[package]]
 name = "tauri"
@@ -5250,7 +5282,7 @@ dependencies = [
  "libc",
  "pkg-config",
  "soup3-sys",
- "system-deps",
+ "system-deps 6.2.2",
 ]
 
 [[package]]

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -332,9 +332,9 @@ checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
 
 [[package]]
 name = "bitflags"
-version = "2.10.0"
+version = "2.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "812e12b5285cc515a9c72a5c1d3b6d46a19dac5acfef5265968c166106e31dd3"
+checksum = "843867be96c8daad0d758b57df9392b6d8d271134fce549de6ce169ff98a92af"
 dependencies = [
  "serde_core",
 ]
@@ -445,7 +445,7 @@ version = "0.18.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8ca26ef0159422fb77631dc9d17b102f253b876fe1586b03b803e63a309b4ee2"
 dependencies = [
- "bitflags 2.10.0",
+ "bitflags 2.11.0",
  "cairo-sys-rs",
  "glib",
  "libc",
@@ -508,9 +508,9 @@ dependencies = [
 
 [[package]]
 name = "cc"
-version = "1.2.55"
+version = "1.2.56"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "47b26a0954ae34af09b50f0de26458fa95369a0d478d8236d3f93082b219bd29"
+checksum = "aebf35691d1bfb0ac386a69bac2fde4dd276fb618cf8bf4f5318fe285e821bb2"
 dependencies = [
  "find-msvc-tools",
  "jobserver",
@@ -626,7 +626,7 @@ version = "0.24.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fa95a34622365fa5bbf40b20b75dba8dfa8c94c734aea8ac9a5ca38af14316f1"
 dependencies = [
- "bitflags 2.10.0",
+ "bitflags 2.11.0",
  "core-foundation",
  "core-graphics-types",
  "foreign-types",
@@ -639,7 +639,7 @@ version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3d44a101f213f6c4cdc1853d4b78aef6db6bdfa3468798cc1d9912f4735013eb"
 dependencies = [
- "bitflags 2.10.0",
+ "bitflags 2.11.0",
  "core-foundation",
  "libc",
 ]
@@ -859,7 +859,7 @@ version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "89a09f22a6c6069a18470eb92d2298acf25463f14256d24778e1230d789a2aec"
 dependencies = [
- "bitflags 2.10.0",
+ "bitflags 2.11.0",
  "block2",
  "libc",
  "objc2",
@@ -1511,7 +1511,7 @@ version = "0.18.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "233daaf6e83ae6a12a52055f568f9d7cf4671dabb78ff9560ab6da230ce00ee5"
 dependencies = [
- "bitflags 2.10.0",
+ "bitflags 2.11.0",
  "futures-channel",
  "futures-core",
  "futures-executor",
@@ -1940,7 +1940,7 @@ dependencies = [
  "image-webp",
  "moxcms",
  "num-traits",
- "png 0.18.0",
+ "png 0.18.1",
  "qoi",
  "ravif",
  "rayon",
@@ -2174,7 +2174,7 @@ version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b750dcadc39a09dbadd74e118f6dd6598df77fa01df0cfcdc52c28dece74528a"
 dependencies = [
- "bitflags 2.10.0",
+ "bitflags 2.11.0",
  "serde",
  "unicode-segmentation",
 ]
@@ -2235,9 +2235,9 @@ dependencies = [
 
 [[package]]
 name = "libc"
-version = "0.2.181"
+version = "0.2.182"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "459427e2af2b9c839b132acb702a1c654d95e10f8c326bfc2ad11310e458b1c5"
+checksum = "6800badb6cb2082ffd7b6a67e6125bb39f18782f793520caee8cb8846be06112"
 
 [[package]]
 name = "libfuzzer-sys"
@@ -2289,7 +2289,7 @@ version = "0.1.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3d0b95e02c851351f877147b7deea7b1afb1df71b63aa5f8270716e0c5720616"
 dependencies = [
- "bitflags 2.10.0",
+ "bitflags 2.11.0",
  "libc",
 ]
 
@@ -2466,7 +2466,7 @@ version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c3f42e7bbe13d351b6bead8286a43aac9534b82bd3cc43e47037f012ebfd62d4"
 dependencies = [
- "bitflags 2.10.0",
+ "bitflags 2.11.0",
  "jni-sys",
  "log",
  "ndk-sys",
@@ -2611,7 +2611,7 @@ version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d49e936b501e5c5bf01fda3a9452ff86dc3ea98ad5f283e1455153142d97518c"
 dependencies = [
- "bitflags 2.10.0",
+ "bitflags 2.11.0",
  "block2",
  "libc",
  "objc2",
@@ -2632,7 +2632,7 @@ version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "73ad74d880bb43877038da939b7427bba67e9dd42004a18b809ba7d87cee241c"
 dependencies = [
- "bitflags 2.10.0",
+ "bitflags 2.11.0",
  "objc2",
  "objc2-foundation",
 ]
@@ -2643,7 +2643,7 @@ version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0b402a653efbb5e82ce4df10683b6b28027616a2715e90009947d50b8dd298fa"
 dependencies = [
- "bitflags 2.10.0",
+ "bitflags 2.11.0",
  "objc2",
  "objc2-foundation",
 ]
@@ -2654,7 +2654,7 @@ version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2a180dd8642fa45cdb7dd721cd4c11b1cadd4929ce112ebd8b9f5803cc79d536"
 dependencies = [
- "bitflags 2.10.0",
+ "bitflags 2.11.0",
  "dispatch2",
  "objc2",
 ]
@@ -2665,7 +2665,7 @@ version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e022c9d066895efa1345f8e33e584b9f958da2fd4cd116792e15e07e4720a807"
 dependencies = [
- "bitflags 2.10.0",
+ "bitflags 2.11.0",
  "dispatch2",
  "objc2",
  "objc2-core-foundation",
@@ -2688,7 +2688,7 @@ version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0cde0dfb48d25d2b4862161a4d5fcc0e3c24367869ad306b0c9ec0073bfed92d"
 dependencies = [
- "bitflags 2.10.0",
+ "bitflags 2.11.0",
  "objc2",
  "objc2-core-foundation",
  "objc2-core-graphics",
@@ -2700,7 +2700,7 @@ version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d425caf1df73233f29fd8a5c3e5edbc30d2d4307870f802d18f00d83dc5141a6"
 dependencies = [
- "bitflags 2.10.0",
+ "bitflags 2.11.0",
  "objc2",
  "objc2-core-foundation",
  "objc2-core-graphics",
@@ -2728,7 +2728,7 @@ version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e3e0adef53c21f888deb4fa59fc59f7eb17404926ee8a6f59f5df0fd7f9f3272"
 dependencies = [
- "bitflags 2.10.0",
+ "bitflags 2.11.0",
  "block2",
  "libc",
  "objc2",
@@ -2741,7 +2741,7 @@ version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "180788110936d59bab6bd83b6060ffdfffb3b922ba1396b312ae795e1de9d81d"
 dependencies = [
- "bitflags 2.10.0",
+ "bitflags 2.11.0",
  "objc2",
  "objc2-core-foundation",
 ]
@@ -2762,7 +2762,7 @@ version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "96c1358452b371bf9f104e21ec536d37a650eb10f7ee379fff67d2e08d537f1f"
 dependencies = [
- "bitflags 2.10.0",
+ "bitflags 2.11.0",
  "objc2",
  "objc2-core-foundation",
  "objc2-foundation",
@@ -2774,7 +2774,7 @@ version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "709fe137109bd1e8b5a99390f77a7d8b2961dafc1a1c5db8f2e60329ad6d895a"
 dependencies = [
- "bitflags 2.10.0",
+ "bitflags 2.11.0",
  "objc2",
  "objc2-core-foundation",
 ]
@@ -2785,7 +2785,7 @@ version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d87d638e33c06f577498cbcc50491496a3ed4246998a7fbba7ccb98b1e7eab22"
 dependencies = [
- "bitflags 2.10.0",
+ "bitflags 2.11.0",
  "objc2",
  "objc2-core-foundation",
  "objc2-foundation",
@@ -2797,7 +2797,7 @@ version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b2e5aaab980c433cf470df9d7af96a7b46a9d892d521a2cbbb2f8a4c16751e7f"
 dependencies = [
- "bitflags 2.10.0",
+ "bitflags 2.11.0",
  "block2",
  "objc2",
  "objc2-app-kit",
@@ -3110,11 +3110,11 @@ dependencies = [
 
 [[package]]
 name = "png"
-version = "0.18.0"
+version = "0.18.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "97baced388464909d42d89643fe4361939af9b7ce7a31ee32a168f832a70f2a0"
+checksum = "60769b8b31b2a9f263dae2776c37b1b28ae246943cf719eb6946a1db05128a61"
 dependencies = [
- "bitflags 2.10.0",
+ "bitflags 2.11.0",
  "crc32fast",
  "fdeflate",
  "flate2",
@@ -3502,7 +3502,7 @@ version = "0.5.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ed2bf2547551a7053d6fdfafda3f938979645c44812fbfcda098faae3f1a362d"
 dependencies = [
- "bitflags 2.10.0",
+ "bitflags 2.11.0",
 ]
 
 [[package]]
@@ -3665,7 +3665,7 @@ version = "1.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "146c9e247ccc180c1f61615433868c99f3de3ae256a30a43b49f67c2d9171f34"
 dependencies = [
- "bitflags 2.10.0",
+ "bitflags 2.11.0",
  "errno",
  "libc",
  "linux-raw-sys",
@@ -4163,7 +4163,7 @@ version = "0.34.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f3a753bdc39c07b192151523a3f77cd0394aa75413802c883a0f6f6a0e5ee2e7"
 dependencies = [
- "bitflags 2.10.0",
+ "bitflags 2.11.0",
  "block2",
  "core-foundation",
  "core-graphics",
@@ -4747,9 +4747,9 @@ dependencies = [
 
 [[package]]
 name = "toml_parser"
-version = "1.0.7+spec-1.1.0"
+version = "1.0.8+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "247eaa3197818b831697600aadf81514e577e0cba5eab10f7e064e78ae154df1"
+checksum = "0742ff5ff03ea7e67c8ae6c93cac239e0d9784833362da3f9a9c1da8dfefcbdc"
 dependencies = [
  "winnow 0.7.14",
 ]
@@ -4781,7 +4781,7 @@ version = "0.6.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d4e6559d53cc268e5031cd8429d05415bc4cb4aefc4aa5d6cc35fbf5b924a1f8"
 dependencies = [
- "bitflags 2.10.0",
+ "bitflags 2.11.0",
  "bytes",
  "futures-util",
  "http",
@@ -4985,11 +4985,11 @@ checksum = "b6c140620e7ffbb22c2dee59cafe6084a59b5ffc27a8859a5f0d494b5d52b6be"
 
 [[package]]
 name = "uuid"
-version = "1.20.0"
+version = "1.21.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ee48d38b119b0cd71fe4141b30f5ba9c7c5d9f4e7a3a8b4a674e4b6ef789976f"
+checksum = "b672338555252d43fd2240c714dc444b8c6fb0a5c5335e65a07bba7742735ddb"
 dependencies = [
- "getrandom 0.3.4",
+ "getrandom 0.4.1",
  "js-sys",
  "serde_core",
  "wasm-bindgen",
@@ -5193,7 +5193,7 @@ version = "0.244.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "47b807c72e1bac69382b3a6fb3dbe8ea4c0ed87ff5629b8685ae6b9a611028fe"
 dependencies = [
- "bitflags 2.10.0",
+ "bitflags 2.11.0",
  "hashbrown 0.15.5",
  "indexmap 2.13.0",
  "semver",
@@ -5825,7 +5825,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9d66ea20e9553b30172b5e831994e35fbde2d165325bec84fc43dbf6f4eb9cb2"
 dependencies = [
  "anyhow",
- "bitflags 2.10.0",
+ "bitflags 2.11.0",
  "indexmap 2.13.0",
  "log",
  "serde",
@@ -5863,9 +5863,9 @@ checksum = "9edde0db4769d2dc68579893f2306b26c6ecfbe0ef499b013d731b7b9247e0b9"
 
 [[package]]
 name = "wry"
-version = "0.54.1"
+version = "0.54.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5ed1a195b0375491dd15a7066a10251be217ce743cf4bbbbdcf5391d6473bee0"
+checksum = "bb26159b420aa77684589a744ae9a9461a95395b848764ad12290a14d960a11a"
 dependencies = [
  "base64 0.22.1",
  "block2",

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -341,6 +341,12 @@ dependencies = [
 
 [[package]]
 name = "bitstream-io"
+version = "2.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6099cdc01846bc367c4e7dd630dc5966dccf36b652fae7a74e17b640411a91b2"
+
+[[package]]
+name = "bitstream-io"
 version = "4.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "60d4bd9d1db2c6bdf285e223a7fa369d5ce98ec767dec949c6ca62863ce61757"
@@ -399,6 +405,12 @@ dependencies = [
  "alloc-no-stdlib",
  "alloc-stdlib",
 ]
+
+[[package]]
+name = "built"
+version = "0.7.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "56ed6191a7e78c36abdb16ab65341eefd73d64d303fffccdbb00d51e4205967b"
 
 [[package]]
 name = "built"
@@ -571,6 +583,15 @@ dependencies = [
  "num-traits",
  "serde",
  "windows-link 0.2.1",
+]
+
+[[package]]
+name = "cmake"
+version = "0.1.57"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "75443c44cd6b379beb8c5b45d85d0773baf31cce901fe7bb252f4eff3008ef7d"
+dependencies = [
+ "cc",
 ]
 
 [[package]]
@@ -2078,6 +2099,15 @@ dependencies = [
 
 [[package]]
 name = "itertools"
+version = "0.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ba291022dbbd398a455acf126c1e341954079855bc60dfdda641363bd6922569"
+dependencies = [
+ "either",
+]
+
+[[package]]
+name = "itertools"
 version = "0.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2b192c782037fadd9cfa75548310488aabdbf3d2da73885b31bd0abd03351285"
@@ -2244,10 +2274,50 @@ dependencies = [
 ]
 
 [[package]]
+name = "libavif"
+version = "0.14.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0b710faf0de92da0e32a9a9c89bbf849e37277fd447b4f17b0f0f798796ae1f2"
+dependencies = [
+ "libavif-sys",
+]
+
+[[package]]
+name = "libavif-image"
+version = "0.14.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b0a6b5ea7c9d9260fa57daa8f238992de5d9c7a3c82a78e8dbc4d1367e7c28be"
+dependencies = [
+ "image",
+ "libavif",
+]
+
+[[package]]
+name = "libavif-sys"
+version = "0.17.0+libavif.1.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "490ca74b61e773140bebb086c81facb23273a99364a9ab0c92ab1532b90ade35"
+dependencies = [
+ "cmake",
+ "libc",
+ "libdav1d-sys",
+ "rav1e 0.7.1",
+]
+
+[[package]]
 name = "libc"
 version = "0.2.182"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6800badb6cb2082ffd7b6a67e6125bb39f18782f793520caee8cb8846be06112"
+
+[[package]]
+name = "libdav1d-sys"
+version = "0.7.1+libdav1d.1.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3d875e9669d116a603412a126de599b7bf47789a365b79fcf461fbf9c18d141f"
+dependencies = [
+ "libc",
+]
 
 [[package]]
 name = "libfuzzer-sys"
@@ -2471,6 +2541,15 @@ dependencies = [
  "serde",
  "thiserror 2.0.18",
  "windows-sys 0.60.2",
+]
+
+[[package]]
+name = "nasm-rs"
+version = "0.2.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fe4d98d0065f4b1daf164b3eafb11974c94662e5e2396cf03f32d0bb5c17da51"
+dependencies = [
+ "rayon",
 ]
 
 [[package]]
@@ -3435,6 +3514,43 @@ dependencies = [
 
 [[package]]
 name = "rav1e"
+version = "0.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cd87ce80a7665b1cce111f8a16c1f3929f6547ce91ade6addf4ec86a8dda5ce9"
+dependencies = [
+ "arbitrary",
+ "arg_enum_proc_macro",
+ "arrayvec",
+ "av1-grain",
+ "bitstream-io 2.6.0",
+ "built 0.7.7",
+ "cc",
+ "cfg-if",
+ "interpolate_name",
+ "itertools 0.12.1",
+ "libc",
+ "libfuzzer-sys",
+ "log",
+ "maybe-rayon",
+ "nasm-rs",
+ "new_debug_unreachable",
+ "noop_proc_macro",
+ "num-derive",
+ "num-traits",
+ "once_cell",
+ "paste",
+ "profiling",
+ "rand 0.8.5",
+ "rand_chacha 0.3.1",
+ "scan_fmt",
+ "simd_helpers",
+ "system-deps 6.2.2",
+ "thiserror 1.0.69",
+ "v_frame",
+]
+
+[[package]]
+name = "rav1e"
 version = "0.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "43b6dd56e85d9483277cde964fd1bdb0428de4fec5ebba7540995639a21cb32b"
@@ -3445,11 +3561,11 @@ dependencies = [
  "arrayvec",
  "av-scenechange",
  "av1-grain",
- "bitstream-io",
- "built",
+ "bitstream-io 4.9.0",
+ "built 0.8.0",
  "cfg-if",
  "interpolate_name",
- "itertools",
+ "itertools 0.14.0",
  "libc",
  "libfuzzer-sys",
  "log",
@@ -3478,7 +3594,7 @@ dependencies = [
  "imgref",
  "loop9",
  "quick-error",
- "rav1e",
+ "rav1e 0.8.1",
  "rayon",
  "rgb",
 ]
@@ -3653,6 +3769,7 @@ dependencies = [
  "image",
  "imagequant",
  "infer 0.16.0",
+ "libavif-image",
  "libheif-rs",
  "serde",
  "serde_json",
@@ -3699,6 +3816,12 @@ checksum = "93fc1dc3aaa9bfed95e02e6eadabb4baf7e3078b0bd1b4d7b6b0b68378900502"
 dependencies = [
  "winapi-util",
 ]
+
+[[package]]
+name = "scan_fmt"
+version = "0.2.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0b53b0a5db882a8e2fdaae0a43f7b39e7e9082389e978398bdf223a55b581248"
 
 [[package]]
 name = "schemars"

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -995,6 +995,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "enumn"
+version = "0.1.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2f9ed6b3789237c8a0c1c505af1c7eb2c560df6186f01b098c3a1064ea532f38"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.115",
+]
+
+[[package]]
 name = "equator"
 version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1185,6 +1196,12 @@ checksum = "cb4cb245038516f5f85277875cdaa4f7d2c9a0fa0468de06ed190163b1581fcf"
 dependencies = [
  "percent-encoding",
 ]
+
+[[package]]
+name = "four-cc"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "795cbfc56d419a7ce47ccbb7504dd9a5b7c484c083c356e797de08bd988d9629"
 
 [[package]]
 name = "futf"
@@ -2230,6 +2247,30 @@ checksum = "f12a681b7dd8ce12bff52488013ba614b869148d54dd79836ab85aafdd53f08d"
 dependencies = [
  "arbitrary",
  "cc",
+]
+
+[[package]]
+name = "libheif-rs"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e4a26370abb4723a3ce73083e479b98017604206cadb0e35da5eac4813600d85"
+dependencies = [
+ "enumn",
+ "four-cc",
+ "libc",
+ "libheif-sys",
+]
+
+[[package]]
+name = "libheif-sys"
+version = "3.1.0+1.18.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e663db80d4272b60c066c5a9d17370ffa0433a31d424152f95f1e1effb9b3860"
+dependencies = [
+ "libc",
+ "pkg-config",
+ "vcpkg",
+ "walkdir",
 ]
 
 [[package]]
@@ -3599,6 +3640,7 @@ dependencies = [
  "image",
  "imagequant",
  "infer 0.16.0",
+ "libheif-rs",
  "serde",
  "serde_json",
  "tauri",
@@ -4963,6 +5005,12 @@ dependencies = [
  "num-traits",
  "wasm-bindgen",
 ]
+
+[[package]]
+name = "vcpkg"
+version = "0.2.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "accd4ea62f7bb7a82fe23066fb0957d48ef677f6eeb8215f372f52e48bb32426"
 
 [[package]]
 name = "version-compare"

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -23,7 +23,7 @@ tauri-plugin-opener = "2"
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 tauri-plugin-dialog = "2.6.0"
-image = { version = "0.25.9", features = ["jpeg", "png", "avif", "avif-encoder"] }
+image = { version = "0.25.9", features = ["jpeg", "png", "avif"] }
 anyhow = "1.0.101"
 webpx = "0.1.3"
 imagequant = "4.2"

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -24,6 +24,7 @@ serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 tauri-plugin-dialog = "2.6.0"
 image = { version = "0.25.9", features = ["jpeg", "png", "avif"] }
+libavif-image = "0.14"
 anyhow = "1.0.101"
 webpx = "0.1.3"
 imagequant = "4.2"

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -23,7 +23,7 @@ tauri-plugin-opener = "2"
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 tauri-plugin-dialog = "2.6.0"
-image = { version = "0.25.9", features = ["jpeg", "png"] }
+image = { version = "0.25.9", features = ["jpeg", "png", "avif", "avif-encoder"] }
 anyhow = "1.0.101"
 webpx = "0.1.3"
 imagequant = "4.2"

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -28,4 +28,4 @@ anyhow = "1.0.101"
 webpx = "0.1.3"
 imagequant = "4.2"
 infer = "0.16"
-libheif-rs = "1.0"
+libheif-rs = { version = "2.6", features = ["image", "latest"] }

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -29,4 +29,3 @@ webpx = "0.1.3"
 imagequant = "4.2"
 infer = "0.16"
 libheif-rs = "1.0"
-

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -28,4 +28,5 @@ anyhow = "1.0.101"
 webpx = "0.1.3"
 imagequant = "4.2"
 infer = "0.16"
+libheif-rs = "1.0"
 

--- a/src-tauri/build.rs
+++ b/src-tauri/build.rs
@@ -1,5 +1,5 @@
 fn main() {
-    // Configure libheif for Windows
+    // Configure libheif and libavif for Windows
     #[cfg(target_os = "windows")]
     {
         // Try VCPKG_ROOT first, then VCPKG_INSTALLATION_ROOT (set by ilammy/msvc-dev-cmd)
@@ -20,6 +20,7 @@ fn main() {
             // Fallback for local development
             println!("cargo:rustc-link-search=native=C:/vcpkg/installed/x64-windows/lib");
             println!("cargo:rustc-link-search=native=C:/Program Files/libheif/lib");
+            println!("cargo:rustc-link-search=native=C:/Program Files/libavif/lib");
         }
     }
 

--- a/src-tauri/build.rs
+++ b/src-tauri/build.rs
@@ -1,3 +1,18 @@
 fn main() {
+    // Configure libheif for static linking on Windows
+    #[cfg(target_os = "windows")]
+    {
+        println!("cargo:rustc-env=LIBHEIF_STATIC=1");
+
+        // Windows native build paths (vcpkg, msys2, etc.)
+        if let Ok(vcpkg_root) = std::env::var("VCPKG_ROOT") {
+            println!("cargo:rustc-link-search=native={}/lib", vcpkg_root);
+        }
+
+        // Fallback paths for common Windows build environments
+        println!("cargo:rustc-link-search=native=C:/vcpkg/installed/x64-windows/lib");
+        println!("cargo:rustc-link-search=native=C:/Program Files/libheif/lib");
+    }
+
     tauri_build::build()
 }

--- a/src-tauri/build.rs
+++ b/src-tauri/build.rs
@@ -1,17 +1,26 @@
 fn main() {
-    // Configure libheif for static linking on Windows
+    // Configure libheif for Windows
     #[cfg(target_os = "windows")]
     {
-        println!("cargo:rustc-env=LIBHEIF_STATIC=1");
+        // Try VCPKG_ROOT first, then VCPKG_INSTALLATION_ROOT (set by ilammy/msvc-dev-cmd)
+        let vcpkg_root = std::env::var("VCPKG_ROOT")
+            .or_else(|_| std::env::var("VCPKG_INSTALLATION_ROOT"))
+            .unwrap_or_default();
 
-        // Windows native build paths (vcpkg, msys2, etc.)
-        if let Ok(vcpkg_root) = std::env::var("VCPKG_ROOT") {
-            println!("cargo:rustc-link-search=native={}/lib", vcpkg_root);
+        if !vcpkg_root.is_empty() {
+            println!(
+                "cargo:rustc-link-search=native={}/installed/x64-windows/lib",
+                vcpkg_root
+            );
+            println!(
+                "cargo:rustc-link-search=native={}/installed/x64-windows-static/lib",
+                vcpkg_root
+            );
+        } else {
+            // Fallback for local development
+            println!("cargo:rustc-link-search=native=C:/vcpkg/installed/x64-windows/lib");
+            println!("cargo:rustc-link-search=native=C:/Program Files/libheif/lib");
         }
-
-        // Fallback paths for common Windows build environments
-        println!("cargo:rustc-link-search=native=C:/vcpkg/installed/x64-windows/lib");
-        println!("cargo:rustc-link-search=native=C:/Program Files/libheif/lib");
     }
 
     tauri_build::build()

--- a/src-tauri/src/converter.rs
+++ b/src-tauri/src/converter.rs
@@ -1,4 +1,4 @@
-use crate::converters::{jpg, png, webp, ConflictResolution, ConversionSettings};
+use crate::converters::{avif, jpg, png, webp, ConflictResolution, ConversionSettings};
 use serde::{Deserialize, Serialize};
 use std::fs;
 use std::path::PathBuf;
@@ -28,6 +28,7 @@ pub fn convert_image(
         "jpg" | "jpeg" => "jpg",
         "png" => "png",
         "webp" => "webp",
+        "avif" => "avif",
         _ => return Err(anyhow::anyhow!("Unsupported format: {}", target_format)),
     };
 
@@ -61,6 +62,9 @@ pub fn convert_image(
         }
         "png" => {
             png::convert_to_png(&img, writer, settings)?;
+        }
+        "avif" => {
+            avif::convert_to_avif(&img, writer, settings)?;
         }
         _ => unreachable!(),
     }

--- a/src-tauri/src/converter.rs
+++ b/src-tauri/src/converter.rs
@@ -18,17 +18,17 @@ pub fn convert_image(
 ) -> anyhow::Result<String> {
     let source_path_buf = PathBuf::from(source_path);
 
-    // Handle HEIC input separately due to libheif requirement
-    let img = if source_path_buf
+    // Handle HEIC and AVIF input separately due to specific library requirements
+    let ext = source_path_buf
         .extension()
         .and_then(|s| s.to_str())
         .map(|s| s.to_lowercase())
-        .map(|s| s == "heic" || s == "heif")
-        .unwrap_or(false)
-    {
-        heic::heic_to_dynamic_image(source_path)?
-    } else {
-        image::open(&source_path_buf)?
+        .unwrap_or_default();
+
+    let img = match ext.as_str() {
+        "heic" | "heif" => heic::heic_to_dynamic_image(source_path)?,
+        "avif" => avif::avif_to_dynamic_image(source_path)?,
+        _ => image::open(&source_path_buf)?,
     };
 
     let stem = source_path_buf

--- a/src-tauri/src/converters/avif.rs
+++ b/src-tauri/src/converters/avif.rs
@@ -1,6 +1,13 @@
 use super::ConversionSettings;
 use image::DynamicImage;
 use std::io::Write;
+use std::path::Path;
+
+pub fn avif_to_dynamic_image(path: impl AsRef<Path>) -> anyhow::Result<DynamicImage> {
+    let data = std::fs::read(path)?;
+    let img = libavif_image::read(&data)?;
+    Ok(img)
+}
 
 pub fn convert_to_avif<W: Write>(
     img: &DynamicImage,

--- a/src-tauri/src/converters/avif.rs
+++ b/src-tauri/src/converters/avif.rs
@@ -1,0 +1,25 @@
+use super::ConversionSettings;
+use image::DynamicImage;
+use std::io::Write;
+
+pub fn convert_to_avif<W: Write>(
+    img: &DynamicImage,
+    mut writer: W,
+    settings: &ConversionSettings,
+) -> anyhow::Result<()> {
+    // AVIF encoding through image crate
+    // Note: The image crate's AVIF encoder uses ravif internally
+
+    if settings.lossless {
+        // For lossless encoding, use maximum quality
+        img.write_to(&mut writer, image::ImageFormat::Avif)?;
+    } else {
+        // For lossy encoding, we need to use the avif encoder with quality settings
+        // The image crate doesn't directly expose quality control for AVIF yet,
+        // so we'll use the default encoding for now
+        // TODO: Implement quality control when ravif API is exposed through image crate
+        img.write_to(&mut writer, image::ImageFormat::Avif)?;
+    }
+
+    Ok(())
+}

--- a/src-tauri/src/converters/avif.rs
+++ b/src-tauri/src/converters/avif.rs
@@ -9,17 +9,21 @@ pub fn convert_to_avif<W: Write>(
 ) -> anyhow::Result<()> {
     // AVIF encoding through image crate
     // Note: The image crate's AVIF encoder uses ravif internally
+    // AVIF encoder requires Seek, so we encode to a buffer first
+
+    let mut buffer = std::io::Cursor::new(Vec::new());
 
     if settings.lossless {
         // For lossless encoding, use maximum quality
-        img.write_to(&mut writer, image::ImageFormat::Avif)?;
+        img.write_to(&mut buffer, image::ImageFormat::Avif)?;
     } else {
         // For lossy encoding, we need to use the avif encoder with quality settings
         // The image crate doesn't directly expose quality control for AVIF yet,
         // so we'll use the default encoding for now
         // TODO: Implement quality control when ravif API is exposed through image crate
-        img.write_to(&mut writer, image::ImageFormat::Avif)?;
+        img.write_to(&mut buffer, image::ImageFormat::Avif)?;
     }
 
+    writer.write_all(buffer.get_ref())?;
     Ok(())
 }

--- a/src-tauri/src/converters/heic.rs
+++ b/src-tauri/src/converters/heic.rs
@@ -3,52 +3,183 @@ use image::DynamicImage;
 use std::io::Write;
 
 /// Decode HEIC/HEIF file to DynamicImage
-///
-/// NOTE: This implementation is a placeholder. The libheif-rs API for image
-/// decoding is complex and requires deeper integration. The library provides
-/// access to image handles but pixel data extraction requires navigating
-/// through multiple abstraction layers that aren't fully exposed in the
-/// current API bindings.
-///
-/// For production HEIC input support, consider:
-/// 1. Using a higher-level API wrapper if available
-/// 2. Contributing API improvements to libheif-rs
-/// 3. Using alternative HEIC libraries with better Rust bindings
 pub fn heic_to_dynamic_image(source_path: &str) -> anyhow::Result<DynamicImage> {
     // Read and parse HEIC file
     let ctx = libheif_rs::HeifContext::read_from_file(source_path)
         .map_err(|e| anyhow::anyhow!("Failed to read HEIC file: {:?}", e))?;
 
     // Get the primary image handle
-    let _handle = ctx
+    let handle = ctx
         .primary_image_handle()
         .map_err(|e| anyhow::anyhow!("Failed to get primary image handle: {:?}", e))?;
 
-    // TODO: HEIC decoding implementation
-    // The libheif-rs crate v1.1.0 does not currently expose a stable public API
-    // for converting image handles to pixel data that can be used with the image crate.
-    // This requires:
-    // 1. Understanding the internal libheif decoder state
-    // 2. Accessing raw pixel buffer through unsafe bindings
-    // 3. Converting to acceptable image::DynamicImage format
-    //
-    // For now, we return an informative error to guide users.
-    Err(anyhow::anyhow!(
-        "HEIC input decoding requires implementing libheif-rs pixel data extraction. \
-         The API stability is currently being improved. \
-         Consider using other formats (AVIF, PNG, WebP, JPG) for now."
-    ))
+    // Create LibHeif instance for decoding
+    let lib_heif = libheif_rs::LibHeif::new();
+
+    // Decode image to RGB color space
+    let image = lib_heif
+        .decode(
+            &handle,
+            libheif_rs::ColorSpace::Rgb(libheif_rs::RgbChroma::Rgb),
+            None,
+        )
+        .map_err(|e| anyhow::anyhow!("Failed to decode HEIC image: {:?}", e))?;
+
+    let width = image.width() as u32;
+    let height = image.height() as u32;
+
+    // Extract pixel data from interleaved plane
+    let planes = image.planes();
+    let interleaved_plane = planes
+        .interleaved
+        .ok_or_else(|| anyhow::anyhow!("Failed to get interleaved plane from HEIC"))?;
+
+    let data = interleaved_plane.data.to_vec();
+
+    // Create RgbImage from raw interleaved RGB data
+    let rgb_image = image::RgbImage::from_raw(width, height, data)
+        .ok_or_else(|| anyhow::anyhow!("Failed to create RGB image from HEIC data"))?;
+
+    // Convert to DynamicImage
+    Ok(DynamicImage::ImageRgb8(rgb_image))
 }
 
 /// Convert DynamicImage to HEIC format and write to writer
-/// Note: HEIC encoding is not yet supported via libheif-rs
 pub fn convert_to_heic<W: Write>(
-    _img: &DynamicImage,
-    _writer: W,
-    _settings: &ConversionSettings,
+    img: &DynamicImage,
+    writer: W,
+    settings: &ConversionSettings,
 ) -> anyhow::Result<()> {
-    // HEIC encoding requires encoder API in libheif-rs which is not yet available
-    Err(anyhow::anyhow!(
-        "HEIC encoding is not yet supported. Output format not available."
-    ))
+    // Convert input to RGB8 if needed
+    let rgb_image = img.to_rgb8();
+    let (width, height) = rgb_image.dimensions();
+
+    // Create a new HEIC image (requires u32)
+    let mut heif_img = libheif_rs::Image::new(
+        width,
+        height,
+        libheif_rs::ColorSpace::Rgb(libheif_rs::RgbChroma::C444),
+    )
+    .map_err(|e| anyhow::anyhow!("Failed to create HEIC image: {:?}", e))?;
+
+    // Create RGB planes (requires u32)
+    heif_img
+        .create_plane(libheif_rs::Channel::R, width, height, 8)
+        .map_err(|e| anyhow::anyhow!("Failed to create R plane: {:?}", e))?;
+    heif_img
+        .create_plane(libheif_rs::Channel::G, width, height, 8)
+        .map_err(|e| anyhow::anyhow!("Failed to create G plane: {:?}", e))?;
+    heif_img
+        .create_plane(libheif_rs::Channel::B, width, height, 8)
+        .map_err(|e| anyhow::anyhow!("Failed to create B plane: {:?}", e))?;
+
+    // Get mutable references to planes and fill with data
+    {
+        let mut planes = heif_img.planes_mut();
+        let plane_r = planes
+            .r
+            .as_mut()
+            .ok_or_else(|| anyhow::anyhow!("Failed to get R plane data"))?;
+        let plane_g = planes
+            .g
+            .as_mut()
+            .ok_or_else(|| anyhow::anyhow!("Failed to get G plane data"))?;
+        let plane_b = planes
+            .b
+            .as_mut()
+            .ok_or_else(|| anyhow::anyhow!("Failed to get B plane data"))?;
+
+        // Fill planes from RGB data
+        let rgb_data = rgb_image.as_raw();
+        let stride_r = plane_r.stride;
+        let stride_g = plane_g.stride;
+        let stride_b = plane_b.stride;
+
+        let mut pixel_index = 0;
+        for y in 0..height {
+            let mut row_offset_r = (y as usize) * stride_r;
+            let mut row_offset_g = (y as usize) * stride_g;
+            let mut row_offset_b = (y as usize) * stride_b;
+
+            for _x in 0..width {
+                let r = rgb_data[pixel_index];
+                let g = rgb_data[pixel_index + 1];
+                let b = rgb_data[pixel_index + 2];
+
+                plane_r.data[row_offset_r] = r;
+                plane_g.data[row_offset_g] = g;
+                plane_b.data[row_offset_b] = b;
+
+                row_offset_r += 1;
+                row_offset_g += 1;
+                row_offset_b += 1;
+                pixel_index += 3;
+            }
+        }
+    }
+
+    // Create encoder and encode
+    let lib_heif = libheif_rs::LibHeif::new();
+
+    // Choose encoder based on quality and lossless settings
+    let compression_format = if settings.lossless {
+        libheif_rs::CompressionFormat::Hevc
+    } else {
+        libheif_rs::CompressionFormat::Av1
+    };
+
+    let mut encoder = lib_heif
+        .encoder_for_format(compression_format)
+        .map_err(|e| anyhow::anyhow!("Failed to create encoder: {:?}", e))?;
+
+    // Set quality based on settings
+    if settings.lossless {
+        encoder
+            .set_quality(libheif_rs::EncoderQuality::LossLess)
+            .map_err(|e| anyhow::anyhow!("Failed to set lossless: {:?}", e))?;
+    } else {
+        encoder
+            .set_quality(libheif_rs::EncoderQuality::Lossy(settings.quality))
+            .map_err(|e| anyhow::anyhow!("Failed to set lossy quality: {:?}", e))?;
+    }
+
+    // Encode to context
+    let mut context = libheif_rs::HeifContext::new()
+        .map_err(|e| anyhow::anyhow!("Failed to create HEIC context: {:?}", e))?;
+
+    context
+        .encode_image(&heif_img, &mut encoder, None)
+        .map_err(|e| anyhow::anyhow!("Failed to encode image: {:?}", e))?;
+
+    // Write to temporary file first, then transfer to writer
+    // (libheif-rs requires file paths, not arbitrary writers)
+    let temp_path = std::env::temp_dir().join(format!(
+        "rimgcvt_heic_{}.heic",
+        std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .unwrap_or_default()
+            .as_nanos()
+    ));
+
+    context
+        .write_to_file(
+            temp_path
+                .to_str()
+                .ok_or_else(|| anyhow::anyhow!("Failed to convert temp path to string"))?,
+        )
+        .map_err(|e| anyhow::anyhow!("Failed to write HEIC file: {:?}", e))?;
+
+    // Read temp file and write to provided writer
+    let temp_data = std::fs::read(&temp_path)
+        .map_err(|e| anyhow::anyhow!("Failed to read temp HEIC file: {:?}", e))?;
+
+    // Clean up temp file
+    let _ = std::fs::remove_file(&temp_path);
+
+    // Write data to output writer
+    let mut w = writer;
+    w.write_all(&temp_data)
+        .map_err(|e| anyhow::anyhow!("Failed to write HEIC data to output: {:?}", e))?;
+
+    Ok(())
 }

--- a/src-tauri/src/converters/heic.rs
+++ b/src-tauri/src/converters/heic.rs
@@ -3,33 +3,52 @@ use image::DynamicImage;
 use std::io::Write;
 
 /// Decode HEIC/HEIF file to DynamicImage
+///
+/// NOTE: This implementation is a placeholder. The libheif-rs API for image
+/// decoding is complex and requires deeper integration. The library provides
+/// access to image handles but pixel data extraction requires navigating
+/// through multiple abstraction layers that aren't fully exposed in the
+/// current API bindings.
+///
+/// For production HEIC input support, consider:
+/// 1. Using a higher-level API wrapper if available
+/// 2. Contributing API improvements to libheif-rs
+/// 3. Using alternative HEIC libraries with better Rust bindings
 pub fn heic_to_dynamic_image(source_path: &str) -> anyhow::Result<DynamicImage> {
+    // Read and parse HEIC file
     let ctx = libheif_rs::HeifContext::read_from_file(source_path)
         .map_err(|e| anyhow::anyhow!("Failed to read HEIC file: {:?}", e))?;
 
-    let handle = ctx
+    // Get the primary image handle
+    let _handle = ctx
         .primary_image_handle()
         .map_err(|e| anyhow::anyhow!("Failed to get primary image handle: {:?}", e))?;
 
-    // Get image dimensions (for future use)
-    let _width = handle.width();
-    let _height = handle.height();
-
-    // For now, we'll use the image as-is
-    // A complete implementation would decode the image, but libheif-rs API requires
-    // more complex setup. This is a placeholder for future improvement.
-    // Return a placeholder error for now
+    // TODO: HEIC decoding implementation
+    // The libheif-rs crate v1.1.0 does not currently expose a stable public API
+    // for converting image handles to pixel data that can be used with the image crate.
+    // This requires:
+    // 1. Understanding the internal libheif decoder state
+    // 2. Accessing raw pixel buffer through unsafe bindings
+    // 3. Converting to acceptable image::DynamicImage format
+    //
+    // For now, we return an informative error to guide users.
     Err(anyhow::anyhow!(
-        "HEIC decoding support requires additional implementation. The libheif-rs binding API is complex."
+        "HEIC input decoding requires implementing libheif-rs pixel data extraction. \
+         The API stability is currently being improved. \
+         Consider using other formats (AVIF, PNG, WebP, JPG) for now."
     ))
 }
 
 /// Convert DynamicImage to HEIC format and write to writer
-/// Note: HEIC encoding is not yet supported
+/// Note: HEIC encoding is not yet supported via libheif-rs
 pub fn convert_to_heic<W: Write>(
     _img: &DynamicImage,
     _writer: W,
     _settings: &ConversionSettings,
 ) -> anyhow::Result<()> {
-    Err(anyhow::anyhow!("HEIC encoding is not yet supported."))
+    // HEIC encoding requires encoder API in libheif-rs which is not yet available
+    Err(anyhow::anyhow!(
+        "HEIC encoding is not yet supported. Output format not available."
+    ))
 }

--- a/src-tauri/src/converters/heic.rs
+++ b/src-tauri/src/converters/heic.rs
@@ -1,0 +1,35 @@
+use super::ConversionSettings;
+use image::DynamicImage;
+use std::io::Write;
+
+/// Decode HEIC/HEIF file to DynamicImage
+pub fn heic_to_dynamic_image(source_path: &str) -> anyhow::Result<DynamicImage> {
+    let ctx = libheif_rs::HeifContext::read_from_file(source_path)
+        .map_err(|e| anyhow::anyhow!("Failed to read HEIC file: {:?}", e))?;
+
+    let handle = ctx
+        .primary_image_handle()
+        .map_err(|e| anyhow::anyhow!("Failed to get primary image handle: {:?}", e))?;
+
+    // Get image dimensions (for future use)
+    let _width = handle.width();
+    let _height = handle.height();
+
+    // For now, we'll use the image as-is
+    // A complete implementation would decode the image, but libheif-rs API requires
+    // more complex setup. This is a placeholder for future improvement.
+    // Return a placeholder error for now
+    Err(anyhow::anyhow!(
+        "HEIC decoding support requires additional implementation. The libheif-rs binding API is complex."
+    ))
+}
+
+/// Convert DynamicImage to HEIC format and write to writer
+/// Note: HEIC encoding is not yet supported
+pub fn convert_to_heic<W: Write>(
+    _img: &DynamicImage,
+    _writer: W,
+    _settings: &ConversionSettings,
+) -> anyhow::Result<()> {
+    Err(anyhow::anyhow!("HEIC encoding is not yet supported."))
+}

--- a/src-tauri/src/converters/mod.rs
+++ b/src-tauri/src/converters/mod.rs
@@ -1,6 +1,7 @@
 use serde::{Deserialize, Serialize};
 
 pub mod avif;
+pub mod heic;
 pub mod jpg;
 pub mod png;
 pub mod webp;

--- a/src-tauri/src/converters/mod.rs
+++ b/src-tauri/src/converters/mod.rs
@@ -1,5 +1,6 @@
 use serde::{Deserialize, Serialize};
 
+pub mod avif;
 pub mod jpg;
 pub mod png;
 pub mod webp;

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -40,6 +40,13 @@
 			"icons/128x128@2x.png",
 			"icons/icon.icns",
 			"icons/icon.ico"
-		]
+		],
+		"windows": {
+			"wix": null,
+			"nsis": {
+				"installerIcon": "icons/icon.ico",
+				"headerImage": "icons/icon.ico"
+			}
+		}
 	}
 }

--- a/src/components/ConversionActionBar.tsx
+++ b/src/components/ConversionActionBar.tsx
@@ -185,6 +185,13 @@ export const ConversionActionBar = ({
                     <RadioGroupItem id="format-jpg" value="jpg" />
                     <span className="text-sm font-medium">JPG</span>
                   </label>
+                  <label
+                    htmlFor="format-avif"
+                    className="flex items-center gap-2 rounded-md border border-transparent px-2 py-1.5 hover:border-primary/20 hover:bg-primary/5 transition-colors"
+                  >
+                    <RadioGroupItem id="format-avif" value="avif" />
+                    <span className="text-sm font-medium">AVIF</span>
+                  </label>
                 </RadioGroup>
               </div>
             </PopoverContent>

--- a/src/components/ConversionActionBar.tsx
+++ b/src/components/ConversionActionBar.tsx
@@ -192,6 +192,13 @@ export const ConversionActionBar = ({
                     <RadioGroupItem id="format-avif" value="avif" />
                     <span className="text-sm font-medium">AVIF</span>
                   </label>
+                  <label
+                    htmlFor="format-heic"
+                    className="flex items-center gap-2 rounded-md border border-transparent px-2 py-1.5 hover:border-primary/20 hover:bg-primary/5 transition-colors"
+                  >
+                    <RadioGroupItem id="format-heic" value="heic" />
+                    <span className="text-sm font-medium">HEIC</span>
+                  </label>
                 </RadioGroup>
               </div>
             </PopoverContent>

--- a/src/components/ConversionActionBar.tsx
+++ b/src/components/ConversionActionBar.tsx
@@ -82,19 +82,25 @@ export const ConversionActionBar = ({
   const hasConvertibleFiles = convertibleCount > 0;
   const qualityLabel = isLossless ? "Lossless" : localQuality;
   const isLosslessDisabled = targetFormat === "jpg";
+  const isQualityControlDisabled = targetFormat === "avif";
   const losslessToggle = (
     <button
       type="button"
       role="switch"
       aria-checked={isLossless}
-      aria-disabled={isLosslessDisabled}
-      onClick={() => !isLosslessDisabled && setIsLossless(!isLossless)}
+      aria-disabled={isLosslessDisabled || isQualityControlDisabled}
+      onClick={() =>
+        !isLosslessDisabled &&
+        !isQualityControlDisabled &&
+        setIsLossless(!isLossless)
+      }
       className={cn(
         "h-5 w-9 rounded-full border border-primary/20 transition-colors",
         isLossless ? "bg-sushi-500" : "bg-muted",
-        isLosslessDisabled && "opacity-50 cursor-not-allowed",
+        (isLosslessDisabled || isQualityControlDisabled) &&
+          "opacity-50 cursor-not-allowed",
       )}
-      disabled={isLosslessDisabled}
+      disabled={isLosslessDisabled || isQualityControlDisabled}
     >
       <span
         className={cn(
@@ -231,14 +237,18 @@ export const ConversionActionBar = ({
                 <div className="flex items-center justify-between">
                   <div className="flex items-center gap-2">
                     <span className="text-sm font-bold">Lossless</span>
-                    {isLosslessDisabled ? (
+                    {isLosslessDisabled || isQualityControlDisabled ? (
                       <TooltipProvider>
                         <Tooltip>
                           <TooltipTrigger asChild>
                             {losslessToggle}
                           </TooltipTrigger>
                           <TooltipContent>
-                            <p>Lossless is not available for JPEG.</p>
+                            <p>
+                              {isLosslessDisabled
+                                ? "Lossless is not available for JPEG."
+                                : "AVIF quality control is not available yet."}
+                            </p>
                           </TooltipContent>
                         </Tooltip>
                       </TooltipProvider>
@@ -256,13 +266,18 @@ export const ConversionActionBar = ({
                   step={1}
                   value={[localQuality]}
                   onValueChange={(value) => setLocalQuality(value[0])}
-                  className={cn("w-full", isLossless && "opacity-50")}
-                  disabled={isLossless}
+                  className={cn(
+                    "w-full",
+                    (isLossless || isQualityControlDisabled) && "opacity-50",
+                  )}
+                  disabled={isLossless || isQualityControlDisabled}
                 />
                 <p className="text-[10px] text-muted-foreground leading-tight">
-                  {isLossless
-                    ? "Lossless conversion ignores the quality slider for this batch."
-                    : `Adjusting here applies only to this conversion batch. Default is ${defaultQuality}.`}
+                  {isQualityControlDisabled
+                    ? "AVIF format doesn't support quality control in this version. Default quality is used."
+                    : isLossless
+                      ? "Lossless conversion ignores the quality slider for this batch."
+                      : `Adjusting here applies only to this conversion batch. Default is ${defaultQuality}.`}
                 </p>
               </div>
             </PopoverContent>

--- a/src/components/ConversionActionBar.tsx
+++ b/src/components/ConversionActionBar.tsx
@@ -80,27 +80,23 @@ export const ConversionActionBar = ({
   const { onStartConversion, onReset, onOpenFolder } = actions;
   const { targetFormat, onTargetFormatChange } = formatSettings;
   const hasConvertibleFiles = convertibleCount > 0;
-  const qualityLabel = isLossless ? "Lossless" : localQuality;
   const isLosslessDisabled = targetFormat === "jpg";
   const isQualityControlDisabled = targetFormat === "avif";
+  const qualityLabel =
+    isLossless || isQualityControlDisabled ? "Lossless" : localQuality;
   const losslessToggle = (
     <button
       type="button"
       role="switch"
       aria-checked={isLossless}
-      aria-disabled={isLosslessDisabled || isQualityControlDisabled}
-      onClick={() =>
-        !isLosslessDisabled &&
-        !isQualityControlDisabled &&
-        setIsLossless(!isLossless)
-      }
+      aria-disabled={isLosslessDisabled}
+      onClick={() => !isLosslessDisabled && setIsLossless(!isLossless)}
       className={cn(
         "h-5 w-9 rounded-full border border-primary/20 transition-colors",
         isLossless ? "bg-sushi-500" : "bg-muted",
-        (isLosslessDisabled || isQualityControlDisabled) &&
-          "opacity-50 cursor-not-allowed",
+        isLosslessDisabled && "opacity-50 cursor-not-allowed",
       )}
-      disabled={isLosslessDisabled || isQualityControlDisabled}
+      disabled={isLosslessDisabled}
     >
       <span
         className={cn(
@@ -211,78 +207,82 @@ export const ConversionActionBar = ({
           </Popover>
         )}
 
-        {!isComplete && (
-          <Popover>
-            <PopoverTrigger asChild>
-              <button
-                type="button"
-                className="flex items-center gap-2.5 px-3 py-1.5 rounded-xl border border-primary/10 hover:bg-primary/5 hover:border-primary/20 transition-all group"
-              >
-                <div className="bg-primary/10 p-1.5 rounded-lg group-hover:bg-primary/20 transition-colors">
-                  <Settings2 className="h-3.5 w-3.5 text-primary" />
-                </div>
-                <div className="flex flex-col items-start leading-tight">
-                  <span className="text-[9px] uppercase tracking-wider font-bold text-muted-foreground">
-                    Quality
-                  </span>
-                  <div className="flex items-center gap-1">
-                    <span className="text-sm font-bold">{qualityLabel}</span>
-                    <ChevronDown className="h-3 w-3 text-muted-foreground" />
+        {!isComplete &&
+          (isQualityControlDisabled ? (
+            <div className="flex items-center gap-2.5 px-3 py-1.5 rounded-xl border border-primary/10 opacity-60">
+              <div className="bg-primary/10 p-1.5 rounded-lg">
+                <Settings2 className="h-3.5 w-3.5 text-primary" />
+              </div>
+              <div className="flex flex-col items-start leading-tight">
+                <span className="text-[9px] uppercase tracking-wider font-bold text-muted-foreground">
+                  Quality
+                </span>
+                <span className="text-sm font-bold">{qualityLabel}</span>
+              </div>
+            </div>
+          ) : (
+            <Popover>
+              <PopoverTrigger asChild>
+                <button
+                  type="button"
+                  className="flex items-center gap-2.5 px-3 py-1.5 rounded-xl border border-primary/10 hover:bg-primary/5 hover:border-primary/20 transition-all group"
+                >
+                  <div className="bg-primary/10 p-1.5 rounded-lg group-hover:bg-primary/20 transition-colors">
+                    <Settings2 className="h-3.5 w-3.5 text-primary" />
                   </div>
-                </div>
-              </button>
-            </PopoverTrigger>
-            <PopoverContent className="w-64 p-4 shadow-xl border-primary/20 backdrop-blur-lg bg-background/95">
-              <div className="space-y-4">
-                <div className="flex items-center justify-between">
-                  <div className="flex items-center gap-2">
-                    <span className="text-sm font-bold">Lossless</span>
-                    {isLosslessDisabled || isQualityControlDisabled ? (
-                      <TooltipProvider>
-                        <Tooltip>
-                          <TooltipTrigger asChild>
-                            {losslessToggle}
-                          </TooltipTrigger>
-                          <TooltipContent>
-                            <p>
-                              {isLosslessDisabled
-                                ? "Lossless is not available for JPEG."
-                                : "AVIF quality control is not available yet."}
-                            </p>
-                          </TooltipContent>
-                        </Tooltip>
-                      </TooltipProvider>
-                    ) : (
-                      losslessToggle
-                    )}
+                  <div className="flex flex-col items-start leading-tight">
+                    <span className="text-[9px] uppercase tracking-wider font-bold text-muted-foreground">
+                      Quality
+                    </span>
+                    <div className="flex items-center gap-1">
+                      <span className="text-sm font-bold">{qualityLabel}</span>
+                      <ChevronDown className="h-3 w-3 text-muted-foreground" />
+                    </div>
                   </div>
-                  <span className="text-sm font-mono bg-muted px-2 py-0.5 rounded leading-none">
-                    {qualityLabel}
-                  </span>
-                </div>
-                <Slider
-                  min={1}
-                  max={100}
-                  step={1}
-                  value={[localQuality]}
-                  onValueChange={(value) => setLocalQuality(value[0])}
-                  className={cn(
-                    "w-full",
-                    (isLossless || isQualityControlDisabled) && "opacity-50",
-                  )}
-                  disabled={isLossless || isQualityControlDisabled}
-                />
-                <p className="text-[10px] text-muted-foreground leading-tight">
-                  {isQualityControlDisabled
-                    ? "AVIF format doesn't support quality control in this version. Default quality is used."
-                    : isLossless
+                </button>
+              </PopoverTrigger>
+              <PopoverContent className="w-64 p-4 shadow-xl border-primary/20 backdrop-blur-lg bg-background/95">
+                <div className="space-y-4">
+                  <div className="flex items-center justify-between">
+                    <div className="flex items-center gap-2">
+                      <span className="text-sm font-bold">Lossless</span>
+                      {isLosslessDisabled ? (
+                        <TooltipProvider>
+                          <Tooltip>
+                            <TooltipTrigger asChild>
+                              {losslessToggle}
+                            </TooltipTrigger>
+                            <TooltipContent>
+                              <p>Lossless is not available for JPEG.</p>
+                            </TooltipContent>
+                          </Tooltip>
+                        </TooltipProvider>
+                      ) : (
+                        losslessToggle
+                      )}
+                    </div>
+                    <span className="text-sm font-mono bg-muted px-2 py-0.5 rounded leading-none">
+                      {qualityLabel}
+                    </span>
+                  </div>
+                  <Slider
+                    min={1}
+                    max={100}
+                    step={1}
+                    value={[localQuality]}
+                    onValueChange={(value) => setLocalQuality(value[0])}
+                    className={cn("w-full", isLossless && "opacity-50")}
+                    disabled={isLossless}
+                  />
+                  <p className="text-[10px] text-muted-foreground leading-tight">
+                    {isLossless
                       ? "Lossless conversion ignores the quality slider for this batch."
                       : `Adjusting here applies only to this conversion batch. Default is ${defaultQuality}.`}
-                </p>
-              </div>
-            </PopoverContent>
-          </Popover>
-        )}
+                  </p>
+                </div>
+              </PopoverContent>
+            </Popover>
+          ))}
 
         <Button
           size="lg"

--- a/src/components/DropZone.tsx
+++ b/src/components/DropZone.tsx
@@ -47,7 +47,15 @@ interface DropZoneProps {
   hasFiles?: boolean;
 }
 
-const SUPPORTED_IMAGE_EXTENSIONS = ["jpg", "jpeg", "png", "webp", "avif"];
+const SUPPORTED_IMAGE_EXTENSIONS = [
+  "jpg",
+  "jpeg",
+  "png",
+  "webp",
+  "avif",
+  "heic",
+  "heif",
+];
 
 const isSupportedImagePath = (path: string) => {
   const extension = path.split(".").pop()?.toLowerCase();

--- a/src/components/DropZone.tsx
+++ b/src/components/DropZone.tsx
@@ -47,7 +47,7 @@ interface DropZoneProps {
   hasFiles?: boolean;
 }
 
-const SUPPORTED_IMAGE_EXTENSIONS = ["jpg", "jpeg", "png", "webp"];
+const SUPPORTED_IMAGE_EXTENSIONS = ["jpg", "jpeg", "png", "webp", "avif"];
 
 const isSupportedImagePath = (path: string) => {
   const extension = path.split(".").pop()?.toLowerCase();

--- a/src/lib/file-utils.ts
+++ b/src/lib/file-utils.ts
@@ -9,6 +9,7 @@ const SUPPORTED_IMAGE_MIME_TYPES = new Set([
   "image/jpeg",
   "image/png",
   "image/webp",
+  "image/avif",
 ]);
 
 export const resolvePathsToFiles = async (

--- a/src/lib/file-utils.ts
+++ b/src/lib/file-utils.ts
@@ -10,6 +10,8 @@ const SUPPORTED_IMAGE_MIME_TYPES = new Set([
   "image/png",
   "image/webp",
   "image/avif",
+  "image/heic",
+  "image/heif",
 ]);
 
 export const resolvePathsToFiles = async (

--- a/src/pages/LicensePage.tsx
+++ b/src/pages/LicensePage.tsx
@@ -132,6 +132,20 @@ const libraries: Library[] = [
     description: "Infer file type by checking magic bytes.",
   },
   {
+    name: "libheif-rs (Rust Crate)",
+    license: "MIT",
+    url: "https://github.com/Cykooz/libheif-rs",
+    description:
+      "Safe Rust wrapper for libheif, supporting HEIC/HEIF image format.",
+  },
+  {
+    name: "libavif-image (Rust Crate)",
+    license: "MIT / Apache-2.0",
+    url: "https://github.com/kornelski/libavif-image",
+    description:
+      "Safe Rust wrapper for libavif, supporting AVIF image decoding.",
+  },
+  {
     name: "anyhow (Rust Crate)",
     license: "MIT / Apache-2.0",
     url: "https://github.com/dtolnay/anyhow",


### PR DESCRIPTION
## 概要

Closes #1

READMEで言及されているHEIC入力サポートを実装し、さらに次世代フォーマットのAVIFサポートも追加します。

## 変更内容

### Phase 1: AVIF対応（入出力両方）
- [ ] Rustバックエンド - AVIF機能有効化
  - `Cargo.toml` の `image` クレート feature 更新（`avif`, `avif-encoder`）
- [ ] AVIFコンバーター実装
  - `src-tauri/src/converters/avif.rs` 新規作成
  - lossless/lossy対応
- [ ] フロントエンド対応
  - `DropZone.tsx`: `SUPPORTED_IMAGE_EXTENSIONS` に `"avif"` 追加
  - `file-utils.ts`: `SUPPORTED_IMAGE_MIME_TYPES` に `"image/avif"` 追加
  - `ConversionActionBar.tsx`: 形式選択UIに「AVIF」追加

### Phase 2: HEIC対応（入出力両方）
- [ ] Rustバックエンド - libheif依存追加
  - `Cargo.toml` に `libheif-rs` 追加
- [ ] HEICコンバーター実装
  - `src-tauri/src/converters/heic.rs` 新規作成
  - デコーダー: `heic_to_dynamic_image()`
  - エンコーダー: `convert_to_heic()` lossless/lossy対応
- [ ] converter.rs 更新
  - HEIC入力処理（`image::open()` の前に分岐）
  - HEIC出力処理（format dispatch）
- [ ] Windows DLLバンドル設定
  - `build.rs` 更新
  - `tauri.conf.json` bundle設定
- [ ] フロントエンド対応
  - Phase 1と同様の手順

## テスト方法

### Phase 1（AVIF）完了後
- [ ] ビルド確認: `bun run tauri build` が成功
- [ ] 入力テスト: AVIF画像→JPG/PNG/WebP変換
- [ ] 出力テスト: 各形式→AVIF変換、lossless/lossy動作確認
- [ ] 品質設定: スライダー値（1-100）がAVIF品質に反映
- [ ] クロスプラットフォーム: macOS/Windows/Linuxでビルド・動作確認

### Phase 2（HEIC）完了後
- [ ] Windows DLLバンドル動作確認
- [ ] macOS動作確認（Homebrew libheif）
- [ ] 入力テスト: iPhone撮影のHEIC画像変換
- [ ] 出力テスト: 各形式→HEIC変換、lossless/lossy動作確認

### 統合テスト
- [ ] 各形式間変換（JPG/PNG/WebP/AVIF/HEIC × 5形式 = 25通り）
- [ ] lossless ON/OFF 切り替え
- [ ] quality値の境界値テスト（1, 50, 100）
- [ ] 大容量ファイル（>10MB）の変換
- [ ] バッチ変換（複数ファイル同時）

## 技術詳細

### ライブラリ選定
- **AVIF**: `image` クレート内蔵の`ravif`（純Rust実装）
- **HEIC**: `libheif-rs`（libheifへのFFIバインディング）

### プラットフォーム対応
- **macOS**: Homebrew経由でlibheif利用可能
- **Windows**: アプリケーションバンドルでDLL同梱（+20MB程度）
- **Linux**: システムパッケージでlibheif利用可能

## チェックリスト

- [ ] Phase 1（AVIF）実装完了
- [ ] Phase 1 テスト完了
- [ ] Phase 2（HEIC）実装完了
- [ ] Phase 2 テスト完了
- [ ] `bun lint` / `bun lint:apply` 実行
- [ ] README更新（必要に応じて）
- [ ] クロスプラットフォームビルド確認